### PR TITLE
Fix paths to point to correct assets in manifest

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -28,7 +28,7 @@ module Webpack
         def asset_paths(source)
           raise WebpackError, manifest["errors"] unless manifest_bundled?
 
-          paths = manifest["assetsByChunkName"][source]
+          paths = manifest["entrypoints"][source]["assets"]
           if paths
             # Can be either a string or an array of strings.
             # Do not include source maps as they are not javascript


### PR DESCRIPTION
This gem is no longer maintained.  Rather than going through the somewhat painful switch to the rails-ified webpacker gem, I've forked this gem to fix the functionality we need in order to enable split chunks.

What needs to be fixed:

Webpack-rails provides a rails-view path-helper-method that allows us to include the webpack-built-js by referring to it as the webpack entry point name, i.e.

webpack.config.js:
```
entry: {
  'coach_calendar': './webpack/coach_calendar.jsx',
}
```

rails view:
```
webpack_asset_path('coach_calendar')
```

It does this by referring to the ```manifest.json``` which is generated on webpack compilation.  When you split chunks, a single entry point can now refer to multiple files.  Unfortunately, as it stands, webpack-rails uses ```assetsByChunkName``` which only points to the chunk which shares the entry point name.  This change will use the correct part of the manifest to get all chunk paths.

example manifest.json:
```
"assetsByChunkName": {
  "coach_calendar": "coach_calendar-0c18a1c2d0165e99873f.js",
  ...
},
...
"entrypoints": {
  "coach_calendar": {
    "chunks": [0, 1, 12],
      "assets": [
"vendors~aggregate_calendar_mini_skill_course~aggregate_coach_calendar~calendar~coach_calendar~coach_~0b71556d-bf78670d1a0fa84b5458.js", 
"vendors~aggregate_calendar_mini_skill_course~aggregate_coach_calendar~coach_calendar~coach_edit~coac~f6e0260c-fda2f7769c8df560b12d.js", 
        "coach_calendar-0c18a1c2d0165e99873f.js"
      ],
      "children": {},
      "childAssets": {}
  },
  ...
}
...
``` 